### PR TITLE
Adding utility method for supported coins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wallet-address-validator",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wallet-address-validator",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "base-x": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tastyworks/wallet-address-validator",
   "description": "Wallet address validator for Bitcoin and other Altcoins.",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "main": "wallet-address-validator.min.js",
   "scripts": {
     "bundle": "browserify src/wallet_address_validator.js --standalone WAValidator --outfile wallet-address-validator.js",

--- a/src/wallet_address_validator.js
+++ b/src/wallet_address_validator.js
@@ -6,10 +6,14 @@ module.exports = {
     validate: function (address, currencyNameOrSymbol, networkType) {
         var currency = currencies.getByNameOrSymbol(currencyNameOrSymbol || DEFAULT_CURRENCY_NAME);
 
-        if (currency.validator) {
+        if (currency && currency.validator) {
             return currency.validator.isValidAddress(address, currency, networkType);
         }
 
         throw new Error('Missing validator for currency: ' + currencyNameOrSymbol);
     },
+    isCurrencySupported: function(currencyNameOrSymbol) {
+        var currency = currencies.getByNameOrSymbol(currencyNameOrSymbol || DEFAULT_CURRENCY_NAME);
+        return !!currency
+    }
 };


### PR DESCRIPTION
* Currently the `validate` method throws an exception if the coin isn't supported (as `currency` is null), meaning the exception around "Missing validator for currency:" is never hit. This does a null check to ensure that a nullpointer exception isn't thrown.
* Added a utility method to check whether a coin is supported, allowing the consumer to check and handle this case before calling validate.
